### PR TITLE
Add test instructions for max_participants enforcement to README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -48,3 +48,13 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Running Tests
+
+To verify the activity signup logic and max_participants enforcement, run:
+
+```
+PYTHONPATH=$(pwd) .venv/bin/python3 tests/test_signup.py
+```
+
+This will check that signups succeed when space is available and fail with HTTP 400 when the activity is full.


### PR DESCRIPTION
This PR updates the README to include instructions for running the new test script that verifies activity signup logic and max_participants enforcement.

- Added a 'Running Tests' section to `src/README.md`.
- Tests can be run with:
  PYTHONPATH=$(pwd) .venv/bin/python3 tests/test_signup.py

Please review and confirm the instructions look correct.